### PR TITLE
add back the function to toggle titles at the top and bottom of the table

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,18 +73,32 @@
           </select>
       </section>
 
-      <label class="el-switch">
-          <span class="margin-r">Tooltips</span>
-          <input type="checkbox" name="switch" id="tooltips" onchange="hideshowtp()" checked hidden>
-          <span class="el-switch-style"></span>
-      </label>
+      <section class="menu-section">
+          <h3 class="menu-section-title">Switch</h3>
+          <label class="el-switch el-switch-sm">
+              <input type="checkbox" name="switch" id="tooltips" onchange="hideshowtp()" checked hidden>
+              <span class="el-switch-style"></span>
+              <span class="margin-r">Tooltips</span>
+          </label>
 
-      <label class="el-switch">
-          <span class="margin-r">Cell Value</span>
-          <input type="checkbox" name="switch" id="cellvalue" onchange="toggleCellValue()" hidden>
-          <span class="el-switch-style"></span>
-      </label>
+          <label class="el-switch el-switch-sm">
+              <input type="checkbox" name="switch" id="cellvalue" onchange="toggleCellValue(true)" hidden>
+              <span class="el-switch-style"></span>
+              <span class="margin-r">Cell Value</span>
+          </label>
 
+          <label class="el-switch el-switch-sm">
+              <input type="checkbox" name="switch" id="bottomtitle" onchange="toggleBottomTitle(true)" hidden>
+              <span class="el-switch-style"></span>
+              <span class="margin-r">Bottom Title</span>
+          </label>
+
+          <label class="el-switch el-switch-sm">
+              <input type="checkbox" name="switch" id="toptitle" onchange="toggleTopTitle(true)" checked hidden>
+              <span class="el-switch-style"></span>
+              <span class="margin-r">Top Title</span>
+          </label>
+      </section>
       <!--hr>
       <section class="menu-section">
           <button type="button" onclick="expandCollapse('expand');">Expand</button>

--- a/lmtstyle.css
+++ b/lmtstyle.css
@@ -82,17 +82,7 @@ p {
    border-top: 1.5px solid black;
 }
 
-/* calculate bottom */
-.tabulator-calcs .tabulator-cell{
-   width:28px;
-   height:288px;
-   writing-mode: vertical-rl;
-   text-orientation: mixed;
-   align-items:center;
-   justify-content:center;
-   font-size:12px;
-   font-weight:300;
-}
+
 
 .tabulator{
    font-size: 8px;
@@ -136,7 +126,6 @@ p {
    text-align: left;
 }
 
-
 .tabulator .tabulator-header .tabulator-frozen.tabulator-frozen-left{
    border-right: 0.1px solid black;
    border-left: 0.0px solid black;
@@ -152,6 +141,19 @@ p {
    border-top: 0.25px solid black;
 }
 
+
+/* calculate bottom */
+.tabulator-calcs .tabulator-cell{
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  align-items:center;
+  justify-content:center;
+  font-size:11px;
+  font-weight: 600;
+  width:28px;
+  height:auto;
+  overflow:auto;
+}
 
 .inputfile {
 	width: 0.1px;
@@ -233,5 +235,21 @@ p {
 .margin-r{
     margin-right:10px;
     vertical-align: top;
-    line-height:1.6;
+    line-height:inherit;
+    font-size: 11px;
+    font-weight: 800;
+    padding-right:60px;
 }
+.el-switch-style {
+    margin-left: 10px;
+}
+
+select[class^="select-choice-"]{
+    margin-left: 10px;
+}
+
+
+.select2-container .select2-selection--single {
+    margin-left: 10px;
+}
+

--- a/lmtstyle.css
+++ b/lmtstyle.css
@@ -153,6 +153,13 @@ p {
   width:28px;
   height:auto;
   overflow:auto;
+  padding-top: 20px;
+  padding-bottom: 60px;
+  padding-left: 0px;
+  padding-right: 0px;
+  text-shadow: 0 1px 0 #f3f3f3;
+  font-style:italic;
+  font-variant:all-small-caps;
 }
 
 .inputfile {


### PR DESCRIPTION


add back the function to toggle titles at the top and bottom of the table.
Showing and hiding the titles at the top and bottom of the table respectively
is the default of the ILAMB style and its counterpart is the default of
the PMP style.